### PR TITLE
docs: clarify db:prepare vs db:setup seed behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `yarn watch:css` - Watch SCSS files and auto-rebuild CSS
 
 ### Database
-- `bin/rails db:prepare` - Setup database (create, migrate, seed)
+- `bin/rails db:prepare` - Setup database if new, or migrate if exists (seeds only on first setup)
+- `bin/rails db:setup` - Create database, load schema, and run seeds (always seeds)
 - `bin/rails db:migrate` - Run pending migrations
 - `bin/rails db:seed` - Load environment-specific seed data
 - `bin/rails db:seed:replant` - Reset and reload seed data


### PR DESCRIPTION
- Add distinction between db:prepare (seeds only on first setup) and db:setup (always seeds)
- Improve accuracy of database command descriptions
- Help developers understand when seeds are executed

🤖 Generated with [Claude Code](https://claude.ai/code)