### PR TITLE
chore(ci): update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -86,7 +86,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: 'yarn'
@@ -98,7 +98,7 @@ jobs:
         run: yarn build:css
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v7 in all CI jobs.
- Update `actions/setup-node` from v4 to v7 and `actions/cache` from v4 to v6.
- Keep PostgreSQL at v17 as requested.

## Compatibility
- CI uses GitHub-hosted `ubuntu-latest`, which supports the Node 24 action runtime required by these action majors.
- `setup-node` caching remains explicitly configured for Yarn.

## Validation
- CI workflow YAML parsing
- `yarn build:css`
- `bundle exec rake parallel:spec` — 49 examples, 0 failures, 4 existing pending
- `bundle exec rubocop -f progress`
- `bundle exec brakeman --no-pager`
- `bundle exec bin/importmap audit`

No Issue created.