### PR TITLE
chore: freeze PostgreSQL Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,12 @@
       "addLabels": [
         "major-update"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "postgres"
+      ],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
- Disable Renovate updates for the `postgres` container image.
- Keep PostgreSQL at v17 until the Fly.io deployment version is decided.

## Validation
- `renovate-config-validator renovate.json`
- `bundle exec rake parallel:spec` — 49 examples, 0 failures, 4 existing pending
- `bundle exec rubocop -f progress`
- `bundle exec brakeman --no-pager`
- `bundle exec bin/importmap audit`

No Issue created.