### PR TITLE
feat: publish static public status pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,5 @@ gem "responders"
 gem "enum_help"
 
 gem "rinku"
+
+gem "aws-sdk-s3", "~> 1.229"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,25 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1281.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.130.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.229.0)
+      aws-sdk-core (~> 3, >= 3.254.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
@@ -192,6 +211,7 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    jmespath (1.6.2)
     json (2.21.2)
     kamal (2.12.0)
       activesupport (>= 7.0)
@@ -494,6 +514,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store
+  aws-sdk-s3 (~> 1.229)
   bootsnap
   bootstrap_form
   brakeman

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A multi-tenant B2B SaaS status page application built with Rails 8.
 - **Role-based access control** with admin/member organization roles
 - **Simple permissions** with organization-level admin/member roles
 - **Incident management** with timeline entries and status tracking
+- **Public static status pages** published to S3 and delivered through CloudFront
 - **Modern UI** with Bootstrap 5, Turbo, and mobile-responsive design
 
 ## Technology Stack
@@ -50,11 +51,7 @@ erDiagram
   ORGANIZATIONS ||--o{ STATUS_PAGES : has_many
 
   STATUS_PAGES ||--o{ INCIDENTS : has_many
-  STATUS_PAGES ||--o{ MEMBERSHIPS : has_many
-
   INCIDENTS ||--o{ INCIDENT_ENTRIES : has_many
-
-  USERS ||--o{ MEMBERSHIPS : has_many
 
   ORGANIZATIONS {
     bigint id PK
@@ -81,7 +78,7 @@ erDiagram
     bigint id PK
     bigint organization_id FK
     string name
-    string url
+    string slug UK
     datetime created_at
     datetime updated_at
   }
@@ -113,6 +110,10 @@ erDiagram
 1. **Organization Level**: Users belong to organizations with `admin` or `member` roles
 2. **Admin Access**: Organization admins can manage status pages, incidents, and incident entries
 3. **Member Access**: Organization members can view all status pages and incidents in their organization
+
+### Public status pages
+
+Each status page is published as static HTML to S3 after a committed change and served at `<slug>.example.com` through CloudFront. See [public status page deployment](docs/public-status-pages.md).
 
 ## CI/CD
 

--- a/app/controllers/status_pages_controller.rb
+++ b/app/controllers/status_pages_controller.rb
@@ -45,6 +45,6 @@ class StatusPagesController < ApplicationController
   end
 
   def status_page_params
-    params.require(:status_page).permit(:name, :url)
+    params.require(:status_page).permit(:name, :slug)
   end
 end

--- a/app/jobs/publish_status_page_job.rb
+++ b/app/jobs/publish_status_page_job.rb
@@ -1,0 +1,12 @@
+class PublishStatusPageJob < ApplicationJob
+  queue_as :default
+
+  retry_on Aws::S3::Errors::ServiceError, Seahorse::Client::NetworkingError, wait: :polynomially_longer, attempts: 5
+
+  def perform(status_page_id)
+    status_page = StatusPage.find_by(id: status_page_id)
+    return unless status_page
+
+    StatusPagePublishing::Publisher.new(status_page).publish
+  end
+end

--- a/app/jobs/unpublish_status_page_job.rb
+++ b/app/jobs/unpublish_status_page_job.rb
@@ -1,0 +1,9 @@
+class UnpublishStatusPageJob < ApplicationJob
+  queue_as :default
+
+  retry_on Aws::S3::Errors::ServiceError, Seahorse::Client::NetworkingError, wait: :polynomially_longer, attempts: 5
+
+  def perform(slug)
+    StatusPagePublishing::Publisher.new(nil).unpublish(slug)
+  end
+end

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -3,4 +3,12 @@ class Incident < ApplicationRecord
   has_many :incident_entries, dependent: :destroy
 
   validates :title, :started_at, presence: true
+
+  after_commit :enqueue_status_page_publication, on: %i[create update destroy]
+
+  private
+
+  def enqueue_status_page_publication
+    PublishStatusPageJob.perform_later(status_page_id)
+  end
 end

--- a/app/models/incident_entry.rb
+++ b/app/models/incident_entry.rb
@@ -11,4 +11,12 @@ class IncidentEntry < ApplicationRecord
 
   validates :status, presence: true
   validates :posted_at, presence: true
+
+  after_commit :enqueue_status_page_publication, on: %i[create update destroy]
+
+  private
+
+  def enqueue_status_page_publication
+    PublishStatusPageJob.perform_later(incident.status_page_id)
+  end
 end

--- a/app/models/status_page.rb
+++ b/app/models/status_page.rb
@@ -5,5 +5,32 @@ class StatusPage < ApplicationRecord
   has_many :incidents, dependent: :destroy
 
   validates :name, presence: true
-  validates :url, presence: true, uniqueness: true
+  validates :slug, presence: true, uniqueness: true,
+                   format: { with: /\A[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\z/, message: "は英小文字・数字・ハイフンで指定してください" }
+
+  after_commit :enqueue_publication, on: %i[create update]
+  after_update_commit :enqueue_previous_slug_removal, if: :saved_change_to_slug?
+  after_destroy_commit :enqueue_removal
+
+  def public_host
+    "#{slug}.#{Rails.configuration.x.status_pages.base_domain}"
+  end
+
+  def public_url
+    "https://#{public_host}"
+  end
+
+  private
+
+  def enqueue_publication
+    PublishStatusPageJob.perform_later(id)
+  end
+
+  def enqueue_previous_slug_removal
+    UnpublishStatusPageJob.perform_later(slug_before_last_save)
+  end
+
+  def enqueue_removal
+    UnpublishStatusPageJob.perform_later(slug)
+  end
 end

--- a/app/services/status_page_publishing/local_storage.rb
+++ b/app/services/status_page_publishing/local_storage.rb
@@ -1,0 +1,19 @@
+require "fileutils"
+
+module StatusPagePublishing
+  class LocalStorage
+    def initialize(root:)
+      @root = Pathname(root)
+    end
+
+    def write(key:, body:, content_type:, cache_control:)
+      path = @root.join(key)
+      FileUtils.mkdir_p(path.dirname)
+      File.binwrite(path, body)
+    end
+
+    def delete(key:)
+      FileUtils.rm_f(@root.join(key))
+    end
+  end
+end

--- a/app/services/status_page_publishing/publisher.rb
+++ b/app/services/status_page_publishing/publisher.rb
@@ -1,0 +1,42 @@
+module StatusPagePublishing
+  class Publisher
+    CONTENT_TYPE = "text/html; charset=utf-8"
+    CACHE_CONTROL = "public, max-age=60, s-maxage=60, stale-while-revalidate=60, stale-if-error=86400"
+
+    def initialize(status_page, storage: Storage.build)
+      @status_page = status_page
+      @storage = storage
+    end
+
+    def publish
+      @storage.write(
+        key: self.class.object_key(@status_page.slug),
+        body: render,
+        content_type: CONTENT_TYPE,
+        cache_control: CACHE_CONTROL
+      )
+    end
+
+    def unpublish(slug)
+      @storage.delete(key: self.class.object_key(slug))
+    end
+
+    def self.object_key(slug)
+      "#{Rails.configuration.x.status_pages.s3_prefix}/#{slug}/index.html"
+    end
+
+    private
+
+    def render
+      ApplicationController.renderer.render(
+        template: "public/status_pages/show",
+        layout: false,
+        assigns: { status_page: @status_page, incidents: incidents, published_at: Time.current }
+      )
+    end
+
+    def incidents
+      @status_page.incidents.includes(:incident_entries).order(started_at: :desc)
+    end
+  end
+end

--- a/app/services/status_page_publishing/s3_storage.rb
+++ b/app/services/status_page_publishing/s3_storage.rb
@@ -1,0 +1,24 @@
+require "aws-sdk-s3"
+
+module StatusPagePublishing
+  class S3Storage
+    def initialize(bucket:, client: Aws::S3::Client.new)
+      @bucket = bucket
+      @client = client
+    end
+
+    def write(key:, body:, content_type:, cache_control:)
+      @client.put_object(
+        bucket: @bucket,
+        key: key,
+        body: body,
+        content_type: content_type,
+        cache_control: cache_control
+      )
+    end
+
+    def delete(key:)
+      @client.delete_object(bucket: @bucket, key: key)
+    end
+  end
+end

--- a/app/services/status_page_publishing/storage.rb
+++ b/app/services/status_page_publishing/storage.rb
@@ -1,0 +1,12 @@
+module StatusPagePublishing
+  class Storage
+    def self.build
+      bucket = Rails.configuration.x.status_pages.s3_bucket
+      return LocalStorage.new(root: Rails.configuration.x.status_pages.local_output_path) if bucket.blank? && !Rails.env.production?
+
+      raise "STATUS_PAGE_S3_BUCKET must be set in production" if bucket.blank?
+
+      S3Storage.new(bucket: bucket)
+    end
+  end
+end

--- a/app/views/public/status_pages/show.html.erb
+++ b/app/views/public/status_pages/show.html.erb
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><%= @status_page.name %> - ステータス</title>
+    <style>
+      :root { color-scheme: light; font-family: system-ui, sans-serif; color: #172033; background: #f5f7fb; }
+      body { margin: 0; }
+      main { max-width: 760px; margin: 0 auto; padding: 48px 20px; }
+      h1 { margin-bottom: 8px; } .updated { color: #5b6474; }
+      .summary, article { background: #fff; border: 1px solid #dbe1eb; border-radius: 10px; padding: 20px; margin-top: 24px; }
+      .summary.ok { border-color: #1f9d55; } .summary.issue { border-color: #d97706; }
+      .badge { display: inline-block; border-radius: 999px; padding: 3px 10px; font-size: .85rem; font-weight: 600; background: #eaf8ef; color: #176b3a; }
+      .badge.issue { background: #fff4e5; color: #9a4c00; } .entry { border-top: 1px solid #e5e9f0; padding-top: 14px; margin-top: 14px; }
+      time { color: #5b6474; font-size: .9rem; } h2 { margin-bottom: 4px; } p { line-height: 1.6; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1><%= @status_page.name %></h1>
+        <p class="updated">最終公開: <time datetime="<%= @published_at.iso8601 %>"><%= l @published_at, format: :long %></time></p>
+      </header>
+
+      <% active_incidents = @incidents.select { |incident| incident.ended_at.nil? } %>
+      <section class="summary <%= active_incidents.any? ? "issue" : "ok" %>">
+        <% if active_incidents.any? %>
+          <strong class="badge issue">障害を確認しています</strong>
+          <p>現在、<%= active_incidents.size %> 件の未解決インシデントがあります。</p>
+        <% else %>
+          <strong class="badge">正常稼働中</strong>
+          <p>現在、報告されている未解決のインシデントはありません。</p>
+        <% end %>
+      </section>
+
+      <section aria-labelledby="incidents">
+        <h2 id="incidents">インシデント履歴</h2>
+        <% if @incidents.empty? %>
+          <p>報告されたインシデントはありません。</p>
+        <% end %>
+        <% @incidents.each do |incident| %>
+          <article>
+            <h3><%= incident.title %></h3>
+            <p>
+              <time datetime="<%= incident.started_at.iso8601 %>"><%= l incident.started_at, format: :long %></time>
+              <% if incident.ended_at.present? %>
+                〜 <time datetime="<%= incident.ended_at.iso8601 %>"><%= l incident.ended_at, format: :long %></time>
+              <% else %>
+                <span class="badge issue">対応中</span>
+              <% end %>
+            </p>
+            <% incident.incident_entries.sort_by(&:posted_at).reverse_each do |entry| %>
+              <div class="entry">
+                <strong><%= t("enums.incident_entry.status.#{entry.status}") %></strong>
+                <time datetime="<%= entry.posted_at.iso8601 %>"><%= l entry.posted_at, format: :long %></time>
+                <%= simple_format(h(entry.body)) %>
+              </div>
+            <% end %>
+          </article>
+        <% end %>
+      </section>
+    </main>
+  </body>
+</html>

--- a/app/views/status_pages/_form.html.erb
+++ b/app/views/status_pages/_form.html.erb
@@ -1,6 +1,6 @@
 <%= bootstrap_form_with(model: status_page, local: true) do |f| %>
   <%= f.text_field :name %>
-  <%= f.text_field :url, placeholder: "https://status.example.com" %>
+  <%= f.text_field :slug, placeholder: "api", help: ".#{Rails.configuration.x.status_pages.base_domain} で公開されます" %>
 
   <%= f.submit class: "btn btn-primary" %>
 <% end %>

--- a/app/views/status_pages/_status_page.html.erb
+++ b/app/views/status_pages/_status_page.html.erb
@@ -3,11 +3,11 @@
     <%= status_page.name %>
   </div>
   <div class="col-4 my-auto">
-    <%= status_page.url %>
+    <%= link_to status_page.public_host, status_page.public_url, target: "_blank", rel: "noopener" %>
   </div>
   <div class="col-4">
     <div class="d-flex justify-content-end">
-      <% if policy(status_page).edit? %>
+      <% if policy(status_page).show? %>
         <%= link_to "インシデント", status_page_incidents_path(status_page), class: "btn btn-sm btn-outline-primary me-2" %>
       <% end %>
       <% if policy(status_page).edit? %>

--- a/app/views/status_pages/_status_page.json.jbuilder
+++ b/app/views/status_pages/_status_page.json.jbuilder
@@ -1,2 +1,3 @@
-json.extract! status_page, :id, :name, :url, :organization_id, :created_at, :updated_at
-json.url status_page_url(status_page, format: :json)
+json.extract! status_page, :id, :name, :slug, :organization_id, :created_at, :updated_at
+json.internal_url status_page_url(status_page, format: :json)
+json.public_url status_page.public_url

--- a/app/views/status_pages/incidents/_incident.html.erb
+++ b/app/views/status_pages/incidents/_incident.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="col-2">
     <div class="d-flex justify-content-end">
-      <% if policy(incident).edit? %>
+      <% if policy(incident).show? %>
         <%= link_to "更新", status_page_incident_path(incident.status_page, incident), class: "btn btn-sm btn-outline-primary me-2" %>
       <% end %>
       <% if policy(incident).destroy? %>
@@ -15,7 +15,7 @@
           <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" id="recordOptionsDropdown" data-bs-toggle="dropdown" aria-expanded="false">その他</button>
           <ul class="dropdown-menu" aria-labelledby="recordOptionsDropdown">
             <li>
-              <%= link_to "削除", incident.status_page, method: :delete, class: "dropdown-item text-danger small", data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
+              <%= link_to "削除", status_page_incident_path(incident.status_page, incident), method: :delete, class: "dropdown-item text-danger small", data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
             </li>
           </ul>
         </div>

--- a/app/views/status_pages/index.html.erb
+++ b/app/views/status_pages/index.html.erb
@@ -21,7 +21,7 @@
         <%= StatusPage.human_attribute_name(:name) %>
       </div>
       <div class="col-4 mt-auto">
-        <%= StatusPage.human_attribute_name(:url) %>
+        <%= StatusPage.human_attribute_name(:slug) %>
       </div>
       <div class="col-4 d-flex justify-content-end">
         &nbsp;

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,11 @@ module SolidStatus
     config.time_zone = "Tokyo"
     config.active_model.i18n_customize_full_message = true
 
+    config.x.status_pages.base_domain = ENV.fetch("STATUS_PAGE_BASE_DOMAIN", "example.com")
+    config.x.status_pages.s3_bucket = ENV["STATUS_PAGE_S3_BUCKET"]
+    config.x.status_pages.s3_prefix = ENV.fetch("STATUS_PAGE_S3_PREFIX", "status-pages")
+    config.x.status_pages.local_output_path = Rails.root.join("tmp", "public_status_pages")
+
     config.generators do |g|
       g.helper false
       g.test_framework :rspec,

--- a/config/cloudfront/status_page_request.js
+++ b/config/cloudfront/status_page_request.js
@@ -1,0 +1,14 @@
+function handler(event) {
+  var request = event.request;
+  var host = request.headers.host.value.toLowerCase();
+  var baseDomain = "example.com"; // Deploy with the production base domain.
+  var suffix = "." + baseDomain;
+
+  if (!host.endsWith(suffix)) return request;
+
+  var slug = host.slice(0, -suffix.length);
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(slug)) return request;
+
+  request.uri = "/status-pages/" + slug + "/index.html";
+  return request;
+}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,6 +22,8 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.cache_store = :null_store
 
+  config.active_job.queue_adapter = :test
+
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -30,7 +30,7 @@ ja:
         name: 組織名
       status_page:
         name: ページ名
-        url: URL
+        slug: サブドメイン
   errors:
     organization_creation_failed: 組織の作成に失敗しました。
   enums:

--- a/db/migrate/20260824120000_add_slug_to_status_pages.rb
+++ b/db/migrate/20260824120000_add_slug_to_status_pages.rb
@@ -1,0 +1,45 @@
+class AddSlugToStatusPages < ActiveRecord::Migration[8.1]
+  class MigrationStatusPage < ActiveRecord::Base
+    self.table_name = "status_pages"
+  end
+
+  def up
+    add_column :status_pages, :slug, :string
+
+    MigrationStatusPage.reset_column_information
+    MigrationStatusPage.find_each do |status_page|
+      status_page.update_columns(slug: unique_slug_for(status_page))
+    end
+
+    change_column_null :status_pages, :slug, false
+    add_index :status_pages, :slug, unique: true
+  end
+
+  def down
+    remove_index :status_pages, :slug
+    remove_column :status_pages, :slug
+  end
+
+  private
+
+  def unique_slug_for(status_page)
+    base_slug = legacy_slug(status_page.url).presence || "status-#{status_page.id}"
+    slug = base_slug
+    suffix = 2
+
+    while MigrationStatusPage.where.not(id: status_page.id).exists?(slug: slug)
+      suffix_text = "-#{suffix}"
+      slug = "#{base_slug.first(63 - suffix_text.length)}#{suffix_text}"
+      suffix += 1
+    end
+
+    slug
+  end
+
+  def legacy_slug(url)
+    host = url.to_s.sub(%r{\Ahttps?://}i, "").split("/").first
+    slug = host.to_s.split(".").first.to_s.downcase.gsub(/[^a-z0-9-]/, "-").gsub(/\A-+|-+\z/, "")
+
+    slug.first(63).presence
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_105000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,9 +53,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_105000) do
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.bigint "organization_id", null: false
+    t.string "slug", null: false
     t.datetime "updated_at", null: false
     t.string "url", default: "", null: false
     t.index ["organization_id"], name: "index_status_pages_on_organization_id"
+    t.index ["slug"], name: "index_status_pages_on_slug", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/docs/public-status-pages.md
+++ b/docs/public-status-pages.md
@@ -1,0 +1,40 @@
+# 公開ステータスページの静的配信
+
+公開ページは Rails から直接応答せず、`<slug>.example.com` を CloudFront 経由で配信します。
+Rails は管理画面と HTML の生成だけを担当します。
+
+```text
+Rails + Solid Queue -> private S3 bucket <- CloudFront (OAC) <- *.example.com
+```
+
+## アプリケーション設定
+
+本番環境では次を設定します。
+
+```sh
+STATUS_PAGE_BASE_DOMAIN=example.com
+STATUS_PAGE_S3_BUCKET=solid-status-public-pages
+STATUS_PAGE_S3_PREFIX=status-pages # 任意。既定値は status-pages
+```
+
+AWS SDK は IAM ロールまたは標準の AWS 認証情報チェーンを使用します。
+`STATUS_PAGE_S3_BUCKET` が本番で未設定の場合、公開ジョブは失敗します。開発・テスト環境では `tmp/public_status_pages/` に同じオブジェクト構成で出力されます。
+
+HTML は `status-pages/<slug>/index.html` に保存されます。インシデント、更新履歴、またはページ本体がコミットされると `PublishStatusPageJob` が再生成します。アップロードに失敗しても、S3 上の直前の正常版は削除されません。S3 の一時的なエラーは最大 5 回再試行します。ページを削除すると `UnpublishStatusPageJob` がオブジェクトを削除します。
+
+## AWS / DNS の構築
+
+1. S3 バケットを作成し、**Block Public Access を有効**にする。
+2. CloudFront ディストリビューションを作成し、S3 をオリジンに指定する。Origin Access Control (OAC) を作成し、バケットポリシーでそのディストリビューションだけに `s3:GetObject` を許可する。
+3. ACM の `us-east-1` で `*.example.com` の DNS 検証済み証明書を発行し、CloudFront の Alternate domain name に設定する。
+4. DNS に `*.example.com` を CloudFront ディストリビューションへ向けるレコードを作成する。
+5. `config/cloudfront/status_page_request.js` の `baseDomain` を実ドメインに置換し、CloudFront Function として Viewer Request に関連付ける。キャッシュポリシーの最小 TTL は `0`、最大 TTL は少なくとも `86400` 秒にして、オリジンの `Cache-Control` を尊重する。
+6. Rails 実行環境へ S3 への `PutObject` と `DeleteObject` だけを許可する IAM ロールを付与し、上記環境変数を設定する。
+
+CloudFront Function は Host ヘッダーの slug を S3 のオブジェクトキーへ変換します。たとえば `api.example.com/anything` は `status-pages/api/index.html` を返します。ワイルドカードは 1 階層だけを対象とするため、`a.b.example.com` は公開対象にしません。
+
+公開 HTML は `Cache-Control: public, max-age=60, s-maxage=60, stale-while-revalidate=60, stale-if-error=86400` で保存されます。通常は60秒で新しい公開版を再検証し、その間は最大60秒間、直前の公開版を返します。S3 が一時的に到達不能または 5xx を返した場合は、CloudFront が直前の公開版を最大24時間返します。CloudFront の cache policy は最小 TTL を `0`、最大 TTL を少なくとも `86400` 秒に設定してください。CloudFront の明示的な invalidation は不要です。
+
+## 初回リリースの境界
+
+対象はプラットフォームが管理する `*.example.com` のみです。顧客が所有する任意のドメインは、DNS 所有確認・証明書ライフサイクル・設定失敗時の運用を含む別機能として扱います。

--- a/spec/factories/status_pages.rb
+++ b/spec/factories/status_pages.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :status_page do
-    name { Faker::Game.title }
-    url  { Faker::Internet.url(host: 'example.com') }
+    sequence(:name) { |n| "Status page #{n}" }
+    sequence(:slug) { |n| "status-#{n}" }
     organization
   end
 end

--- a/spec/jobs/publish_status_page_job_spec.rb
+++ b/spec/jobs/publish_status_page_job_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe PublishStatusPageJob, type: :job do
+  it "renders and stores the current status page" do
+    status_page = create(:status_page)
+    publisher = instance_double(StatusPagePublishing::Publisher, publish: true)
+
+    expect(StatusPagePublishing::Publisher).to receive(:new).with(status_page).and_return(publisher)
+    expect(publisher).to receive(:publish)
+
+    described_class.perform_now(status_page.id)
+  end
+
+  it "does nothing when the page was deleted before the job ran" do
+    expect { described_class.perform_now(-1) }.not_to raise_error
+  end
+end

--- a/spec/jobs/unpublish_status_page_job_spec.rb
+++ b/spec/jobs/unpublish_status_page_job_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe UnpublishStatusPageJob, type: :job do
+  it "removes the stored public page" do
+    publisher = instance_double(StatusPagePublishing::Publisher, unpublish: true)
+
+    expect(StatusPagePublishing::Publisher).to receive(:new).with(nil).and_return(publisher)
+    expect(publisher).to receive(:unpublish).with("api")
+
+    described_class.perform_now("api")
+  end
+end

--- a/spec/models/incident_entry_spec.rb
+++ b/spec/models/incident_entry_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe IncidentEntry, type: :model do
+  include ActiveJob::TestHelper
+
+  self.use_transactional_tests = false
+
+  after do
+    IncidentEntry.delete_all
+    Incident.delete_all
+    StatusPage.delete_all
+    Organization.delete_all
+  end
+
+  it "republishes its incident's status page after it is created" do
+    status_page = create(:status_page)
+    incident = Incident.create!(status_page: status_page, title: "API 障害", started_at: Time.current)
+    clear_enqueued_jobs
+
+    expect {
+      described_class.create!(incident: incident, status: :investigating, body: "調査中です。", posted_at: Time.current)
+    }.to have_enqueued_job(PublishStatusPageJob).with(status_page.id)
+  end
+end
+
+RSpec.describe "incident entry cleanup", type: :model do
+  include ActiveJob::TestHelper
+
+  self.use_transactional_tests = false
+
+  after do
+    IncidentEntry.delete_all
+    Incident.delete_all
+    StatusPage.delete_all
+    Organization.delete_all
+  end
+
+  it "does not fail when its incident is deleted" do
+    status_page = create(:status_page)
+    incident = Incident.create!(status_page: status_page, title: "API 障害", started_at: Time.current)
+    entry = IncidentEntry.create!(incident: incident, status: :investigating, posted_at: Time.current)
+    entry.reload
+    clear_enqueued_jobs
+
+    expect { incident.destroy! }.not_to raise_error
+    expect(enqueued_jobs.map { |job| job["arguments"].first }).to include(status_page.id)
+  end
+end

--- a/spec/models/incident_spec.rb
+++ b/spec/models/incident_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Incident, type: :model do
+  include ActiveJob::TestHelper
+
+  self.use_transactional_tests = false
+
+  after do
+    IncidentEntry.delete_all
+    Incident.delete_all
+    StatusPage.delete_all
+    Organization.delete_all
+  end
+
+  it "republishes its status page after it is created" do
+    status_page = create(:status_page)
+    clear_enqueued_jobs
+
+    expect {
+      described_class.create!(status_page: status_page, title: "API 障害", started_at: Time.current)
+    }.to have_enqueued_job(PublishStatusPageJob).with(status_page.id)
+  end
+end

--- a/spec/models/status_page_spec.rb
+++ b/spec/models/status_page_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe StatusPage, type: :model do
+  include ActiveJob::TestHelper
+
+  self.use_transactional_tests = false
+
+  after do
+    IncidentEntry.delete_all
+    Incident.delete_all
+    StatusPage.delete_all
+    Organization.delete_all
+  end
+
+  describe "public hostname" do
+    subject(:status_page) { build(:status_page, slug: "api") }
+
+    it "builds a hostname and URL from its slug" do
+      expect(status_page.public_host).to eq("api.example.com")
+      expect(status_page.public_url).to eq("https://api.example.com")
+    end
+  end
+
+  describe "publishing" do
+    it "enqueues publishing after creation" do
+      expect { create(:status_page) }
+        .to have_enqueued_job(PublishStatusPageJob)
+        .with(an_instance_of(Integer))
+    end
+
+    it "enqueues removal after destruction" do
+      status_page = create(:status_page, slug: "api")
+      clear_enqueued_jobs
+
+      expect { status_page.destroy! }
+        .to have_enqueued_job(UnpublishStatusPageJob)
+        .with("api")
+    end
+
+    it "publishes the new slug and removes the old static page after a slug change" do
+      status_page = create(:status_page, slug: "api")
+      clear_enqueued_jobs
+
+      status_page.update!(slug: "api-v2")
+
+      expect(enqueued_jobs).to include(a_hash_including("job_class" => "PublishStatusPageJob", "arguments" => [ status_page.id ]))
+      expect(enqueued_jobs).to include(a_hash_including("job_class" => "UnpublishStatusPageJob", "arguments" => [ "api" ]))
+    end
+  end
+end

--- a/spec/requests/status_pages_spec.rb
+++ b/spec/requests/status_pages_spec.rb
@@ -80,21 +80,21 @@ RSpec.describe "/status_pages", type: :request do
     describe "PATCH /update" do
       context "with valid parameters" do
         let(:new_attributes) {
-          skip("Add a hash of attributes valid for your model")
+          { name: "Updated status page", slug: "updated-status-page" }
         }
 
         it "updates the requested status_page" do
           status_page = StatusPage.create! valid_attributes
           patch status_page_url(status_page), params: { status_page: new_attributes }
-          status_page.reload
-          skip("Add assertions for updated state")
+
+          expect(status_page.reload).to have_attributes(new_attributes)
         end
 
-        it "redirects to the status_page" do
+        it "redirects to the status_pages list" do
           status_page = StatusPage.create! valid_attributes
           patch status_page_url(status_page), params: { status_page: new_attributes }
-          status_page.reload
-          expect(response).to redirect_to(status_page_url(status_page))
+
+          expect(response).to redirect_to(status_pages_url)
         end
       end
 
@@ -191,21 +191,22 @@ RSpec.describe "/status_pages", type: :request do
     describe "PATCH /update" do
       context "with valid parameters" do
         let(:new_attributes) {
-          skip("Add a hash of attributes valid for your model")
+          { name: "Updated status page", slug: "updated-status-page" }
         }
 
-        it "updates the requested status_page" do
+        it "does not update the requested status_page" do
           status_page = StatusPage.create! valid_attributes
+          original_attributes = status_page.attributes.slice("name", "slug")
           patch status_page_url(status_page), params: { status_page: new_attributes }
-          status_page.reload
-          skip("Add assertions for updated state")
+
+          expect(status_page.reload.attributes.slice("name", "slug")).to eq(original_attributes)
         end
 
-        it "redirects to the status_page" do
+        it "redirects to the root page" do
           status_page = StatusPage.create! valid_attributes
           patch status_page_url(status_page), params: { status_page: new_attributes }
-          status_page.reload
-          expect(response).to redirect_to(status_page_url(status_page))
+
+          expect(response).to redirect_to(root_url)
         end
       end
 

--- a/spec/services/status_page_publishing/publisher_spec.rb
+++ b/spec/services/status_page_publishing/publisher_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe StatusPagePublishing::Publisher do
+  describe "#publish" do
+    it "stores an escaped static HTML representation of the status page" do
+      status_page = create(:status_page, name: "API Status", slug: "api")
+      incident = Incident.create!(status_page: status_page, title: "API 障害", started_at: Time.zone.parse("2026-08-24 10:00"))
+      IncidentEntry.create!(incident: incident, status: :investigating, body: "<script>alert('xss')</script>", posted_at: Time.zone.parse("2026-08-24 10:05"))
+      storage = instance_double(StatusPagePublishing::LocalStorage)
+
+      expect(storage).to receive(:write) do |key:, body:, content_type:, cache_control:|
+        expect(key).to eq("status-pages/api/index.html")
+        expect(content_type).to eq("text/html; charset=utf-8")
+        expect(cache_control).to eq("public, max-age=60, s-maxage=60, stale-while-revalidate=60, stale-if-error=86400")
+        expect(body).to include("API Status", "API 障害", "調査中")
+        expect(body).to include("&lt;script&gt;alert('xss')&lt;/script&gt;")
+        expect(body).not_to include("<script>")
+      end
+
+      described_class.new(status_page, storage: storage).publish
+    end
+  end
+
+  describe "#unpublish" do
+    it "deletes the static page for the slug" do
+      storage = instance_double(StatusPagePublishing::LocalStorage)
+      expect(storage).to receive(:delete).with(key: "status-pages/api/index.html")
+
+      described_class.new(nil, storage: storage).unpublish("api")
+    end
+  end
+end

--- a/spec/services/status_page_publishing/s3_storage_spec.rb
+++ b/spec/services/status_page_publishing/s3_storage_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe StatusPagePublishing::S3Storage do
+  it "writes static HTML with its cache policy" do
+    client = instance_double(Aws::S3::Client)
+    storage = described_class.new(bucket: "status-pages", client: client)
+
+    expect(client).to receive(:put_object).with(
+      bucket: "status-pages",
+      key: "status-pages/api/index.html",
+      body: "<html></html>",
+      content_type: "text/html; charset=utf-8",
+      cache_control: "no-cache"
+    )
+
+    storage.write(
+      key: "status-pages/api/index.html",
+      body: "<html></html>",
+      content_type: "text/html; charset=utf-8",
+      cache_control: "no-cache"
+    )
+  end
+
+  it "deletes the object when a status page is removed" do
+    client = instance_double(Aws::S3::Client)
+    storage = described_class.new(bucket: "status-pages", client: client)
+
+    expect(client).to receive(:delete_object).with(bucket: "status-pages", key: "status-pages/api/index.html")
+
+    storage.delete(key: "status-pages/api/index.html")
+  end
+end

--- a/spec/system/status_pages/create_spec.rb
+++ b/spec/system/status_pages/create_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'StatusPages', :js do
       visit new_status_page_path
       expect(page).to have_content 'ページ'
       fill_in 'ページ名', with: Faker::Game.title
-      fill_in 'URL', with: Faker::Internet.url(host: 'example.com')
+      fill_in 'サブドメイン', with: "status-#{SecureRandom.hex(4)}"
       click_on '登録する'
       expect(page).to have_content 'ページが作成されました'
     end

--- a/spec/system/status_pages/update_spec.rb
+++ b/spec/system/status_pages/update_spec.rb
@@ -12,13 +12,13 @@ describe 'ページの編集', :js do
 
     expect(page).to have_content 'ページ'
     fill_in 'ページ名', with: Faker::Game.title
-    fill_in 'URL', with: Faker::Internet.url(host: 'example.com')
+    fill_in 'サブドメイン', with: "status-#{SecureRandom.hex(4)}"
     click_on '更新する'
 
     expect(page).to have_content 'ページが更新されました'
   end
 
-  it 'viewであれば更新できない' do
+  it 'メンバーであれば更新できない' do
     sign_in viewer_user
     visit edit_status_page_path(status_page)
     expect(page).to have_content '権限がありません'


### PR DESCRIPTION
## Summary
- generate escaped public status page HTML after committed status page, incident, and entry changes
- publish the artifact to private S3 for CloudFront delivery at `<slug>.example.com`
- add the wildcard-domain, CloudFront Function, and IAM deployment runbook
- replace legacy URL input with a validated public subdomain and complete the pending update specs

## Verification
- `mise exec -- bundle exec rspec --format progress` (63 examples, 0 failures)
- `mise exec -- bin/rails zeitwerk:check`
- `mise exec -- bin/rubocop`
- `mise exec -- bin/brakeman --no-pager`
- local static publish smoke test

## Deployment required
Set `STATUS_PAGE_BASE_DOMAIN` and `STATUS_PAGE_S3_BUCKET`, then configure private S3 + CloudFront OAC + ACM wildcard certificate + DNS as documented in `docs/public-status-pages.md`.